### PR TITLE
Fix tests of variables that are default 0

### DIFF
--- a/gbr
+++ b/gbr
@@ -198,7 +198,7 @@ for REPO in $(echo "$REPOS" | jq '.name' | sed 's/"//g'); do
 
     echo ""
 
-    if [ -n "$DELETE" ]; then
+    if [ "$DELETE" -eq 1 ]; then
       echo "${BOLD}Deleting 'master'...${NORMAL}"
 
       if [ -z "$DRY_RUN" ]; then

--- a/gbr
+++ b/gbr
@@ -77,7 +77,7 @@ if [ -z "$FORCE" ] && [ -z "$DRY_RUN" ]; then
   usage
 fi
 
-if [ -n "$FORCE" ] && [ -n "$DRY_RUN" ]; then
+if [ "$FORCE" -eq 1 ] && [ "$DRY_RUN" -eq 1 ]; then
   usage
 fi
 


### PR DESCRIPTION
On my machine (macOS Mojave, bash 5.0.17) the script has a couple of bugs because in bash `VAR=0 ; [ -n "$VAR" ]` is true:

- I'd get the usage message even when specifying `-n` on the command line
- In dry run mode the master branches would always be deleted even if I didn't specify `--delete`

Making the test more explicit seemed to do the trick.