### PR TITLE
Add -o pipefail

### DIFF
--- a/gbr
+++ b/gbr
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -eo pipefail
 
 BOLD=$(tput bold)
 NORMAL=$(tput sgr0)


### PR DESCRIPTION
This script uses pipes in at least one place and should probably fail
hard if any part of the pipeline fails.